### PR TITLE
FEAT: 매칭에 대한 찜하기 취소 api

### DIFF
--- a/src/main/java/com/umc/meetpick/controller/RequestController.java
+++ b/src/main/java/com/umc/meetpick/controller/RequestController.java
@@ -45,5 +45,12 @@ public class RequestController {
         return ApiResponse.onSuccess(responseDTO);
     }
 
+    @Operation(summary = "매칭 좋아요 취소")
+    @DeleteMapping("/like/{requestId}")
+    public ApiResponse<String> deleteLikeRequest(@PathVariable Long requestId, @RequestParam Long userId) {
+        requestService.deleteLikeRequest(requestId, userId);
+        return ApiResponse.onSuccess("삭제 성공");
+    }
+
 
 }

--- a/src/main/java/com/umc/meetpick/entity/Request.java
+++ b/src/main/java/com/umc/meetpick/entity/Request.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
 import java.util.Set;
 
 @Getter
@@ -85,6 +86,9 @@ public class Request extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "request", cascade = CascadeType.ALL)
     private Set<RequestSubMajor> subMajors;
+
+    @OneToMany(mappedBy = "request", cascade = CascadeType.ALL)
+    private List<MemberLikes> memberLikes;
 
     // 인원 수 초과 방지
     public void addPerson() {

--- a/src/main/java/com/umc/meetpick/repository/MemberLikesRepository.java
+++ b/src/main/java/com/umc/meetpick/repository/MemberLikesRepository.java
@@ -4,6 +4,9 @@ import com.umc.meetpick.entity.MemberLikes;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface MemberLikesRepository extends JpaRepository<MemberLikes, Long> {
+    Optional<MemberLikes> findByRequestId(Long requestId);
 }

--- a/src/main/java/com/umc/meetpick/service/request/RequestService.java
+++ b/src/main/java/com/umc/meetpick/service/request/RequestService.java
@@ -8,4 +8,5 @@ public interface RequestService {
     RequestDTO.JoinRequestDTO createJoinRequest(RequestDTO.JoinRequestDTO request);
     void deleteRequest(Long requestId, Long userId);
     RequestDTO.LikeRequestDTO likeRequest(Long requestId, Long userId);
+    void deleteLikeRequest(Long requestId, Long userId);
 }

--- a/src/main/java/com/umc/meetpick/service/request/RequestServiceImpl.java
+++ b/src/main/java/com/umc/meetpick/service/request/RequestServiceImpl.java
@@ -158,4 +158,16 @@ public class RequestServiceImpl implements RequestService {
                 .postUserId(savedMemberLikes.getMember().getId())
                 .build();
     }
+
+    @Override
+    public void deleteLikeRequest(Long requestId, Long userId){
+
+        MemberLikes memberLikes = memberLikesRepository.findByRequestId(requestId)
+                .orElseThrow(()->new IllegalArgumentException("찜하기 찾을 수 없음"));
+
+        if (!memberLikes.getMember().getId().equals(userId)) {
+            throw new IllegalArgumentException("취소 권한 없음");
+        }
+        memberLikesRepository.delete(memberLikes);
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관 이슈
28

## 📝 요약
매칭에 대한 찜하기 취소 api 완성

## ✅ PR 유형
<!-- 작업한 내용에 체크해주세요 -->
다음과 같은 **변경 사항**이 있습니다.
- [X] 새로운 기능 추가
- [ ] 기존 로직 수정
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (주석 및 오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 문서 수정

## 변경사항 상세
### 작업 내용 요약1
- request entity와 memberlikes entity 양방향 매핑 적용해서 cascade 적용하였습니다. - request 삭제시 memberlikes도 삭제

