### PR TITLE
FIX: 매칭 승낙 or 거절 api 수정

### DIFF
--- a/src/main/java/com/umc/meetpick/controller/RequestController.java
+++ b/src/main/java/com/umc/meetpick/controller/RequestController.java
@@ -52,9 +52,9 @@ public class RequestController {
     }
 
     @Operation(summary = "매칭 신청 승낙하기" )
-    @PatchMapping("/accept/{requestId}")
-    public ApiResponse<RequestDTO.isAcceptedDTO> acceptRequest(@PathVariable Long requestId, @RequestParam Long userId, Boolean isAccepted) {
-        RequestDTO.isAcceptedDTO responseDTO = requestService.acceptRequest(requestId, userId, isAccepted);
+    @PatchMapping("/accept/{matchingRequestId}")
+    public ApiResponse<RequestDTO.isAcceptedDTO> acceptRequest(@PathVariable Long matchingRequestId, @RequestParam Long userId, Boolean isAccepted) {
+        RequestDTO.isAcceptedDTO responseDTO = requestService.acceptRequest(matchingRequestId, userId, isAccepted);
         return ApiResponse.onSuccess(responseDTO);
     }
 }

--- a/src/main/java/com/umc/meetpick/dto/RequestDTO.java
+++ b/src/main/java/com/umc/meetpick/dto/RequestDTO.java
@@ -65,7 +65,7 @@ public class RequestDTO {
     @AllArgsConstructor
     public static class isAcceptedDTO{
         private Boolean isAccepted;
-        private Long requestId;
+        private Long matchingRequestId;
         private Boolean status;
     }
 }

--- a/src/main/java/com/umc/meetpick/service/request/RequestServiceImpl.java
+++ b/src/main/java/com/umc/meetpick/service/request/RequestServiceImpl.java
@@ -218,12 +218,12 @@ public class RequestServiceImpl implements RequestService {
 
     // 매칭 요청에 대한 수락 or 거절
     @Override
-    public RequestDTO.isAcceptedDTO acceptRequest(Long requestId, Long userId, Boolean isAccepted) {
+    public RequestDTO.isAcceptedDTO acceptRequest(Long matchingRequestId, Long userId, Boolean isAccepted) {
 
-        MemberSecondProfile request = memberSecondProfileRepository.findById(requestId)
-                .orElseThrow(()->new EntityNotFoundException("존재하지 않는 매칭"));
+//        MemberSecondProfile request = memberSecondProfileRepository.findById(requestId)
+//                .orElseThrow(()->new EntityNotFoundException("존재하지 않는 매칭"));
 
-        MemberSecondProfileMapping memberSecondProfileMapping = memberMappingRepository.findByMemberSecondProfile(request)
+        MemberSecondProfileMapping memberSecondProfileMapping = memberMappingRepository.findById(matchingRequestId)
                 .orElseThrow(()-> new EntityNotFoundException("신청을 찾을 수 없음"));
 
         if(!memberSecondProfileMapping.getMemberSecondProfile().getMember().getId().equals(userId)) {
@@ -240,7 +240,7 @@ public class RequestServiceImpl implements RequestService {
         MemberSecondProfileMapping updatedMapping = memberMappingRepository.save(memberSecondProfileMapping);
 
         return RequestDTO.isAcceptedDTO.builder()
-                .requestId(updatedMapping.getMemberSecondProfile().getId())
+                .matchingRequestId(updatedMapping.getId())
                 .isAccepted(updatedMapping.getIsAccepted())
                 .status(updatedMapping.getStatus())
                 .build();


### PR DESCRIPTION
## #️⃣ 연관 이슈
58
## 📝 요약
- 기존 로직이 논리적으로 안맞음(매칭id를 가져와서 수락or거절 처리)
- 수정해서 매칭신청id를 바탕으로 수락or거절처리

## ✅ PR 유형
<!-- 작업한 내용에 체크해주세요 -->
다음과 같은 **변경 사항**이 있습니다.
- [ ] 새로운 기능 추가
- [X] 기존 로직 수정
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (주석 및 오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 문서 수정

