### PR TITLE
FIX: submajor 저장 안되는 버그 해결

### DIFF
--- a/src/main/java/com/umc/meetpick/repository/member/MemberSecondProfileSubMajorRepository.java
+++ b/src/main/java/com/umc/meetpick/repository/member/MemberSecondProfileSubMajorRepository.java
@@ -1,0 +1,9 @@
+package com.umc.meetpick.repository.member;
+
+import com.umc.meetpick.entity.mapping.MemberSecondProfileSubMajor;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberSecondProfileSubMajorRepository extends JpaRepository<MemberSecondProfileSubMajor, Long> {
+}

--- a/src/main/java/com/umc/meetpick/service/request/RequestServiceImpl.java
+++ b/src/main/java/com/umc/meetpick/service/request/RequestServiceImpl.java
@@ -39,6 +39,7 @@ public class RequestServiceImpl implements RequestService {
     private final MemberSecondProfileRepository memberSecondProfileRepository;
     private final MemberSecondProfileTimesRepository memberSecondProfileTimesRepository;
     private final PersonalityRepository personalityRepository;
+    private final MemberSecondProfileSubMajorRepository memberSecondProfileSubMajorRepository;
 
     @Override
     public RequestDTO.NewRequestDTO createNewRequest(RequestDTO.NewRequestDTO newRequest) {
@@ -124,6 +125,8 @@ public class RequestServiceImpl implements RequestService {
                             .build();
                 })
                         .toList();
+
+        memberSecondProfileSubMajorRepository.saveAll(subMajorList);
 
         return RequestDTO.NewRequestDTO.builder()
                 .writerId(savedProfile.getMember().getId())


### PR DESCRIPTION
## #️⃣ 연관 이슈

## 📝 요약
> 매칭 삭제 수정하다가 다른 버그 찾아서 우선 pr 올립니다.
- membersecondprofile 생성시 sub major 저장 안되던 경우 해결

## ✅ PR 유형
<!-- 작업한 내용에 체크해주세요 -->
다음과 같은 **변경 사항**이 있습니다.
- [ ] 새로운 기능 추가
- [ ] 기존 로직 수정
- [X] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (주석 및 오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 문서 수정
- 작업 내용 설명

