### PR TITLE
FIX:membersecondprofile 관련 mbti는 스트링으로 변경

### DIFF
--- a/src/main/java/com/umc/meetpick/dto/RequestDTO.java
+++ b/src/main/java/com/umc/meetpick/dto/RequestDTO.java
@@ -26,7 +26,8 @@ public class RequestDTO {
         private int minAge;
         private int maxAge;
         //private List<String> personality;
-        private Set<MBTI> mbti;
+        //private Set<MBTI> mbti;
+        private String mbti;
         private Boolean isHobbySame;
         private List<MemberSecondProfileTimesDTO> memberSecondProfileTimes;
         private int maxPeople;

--- a/src/main/java/com/umc/meetpick/entity/MemberProfiles/MemberSecondProfile.java
+++ b/src/main/java/com/umc/meetpick/entity/MemberProfiles/MemberSecondProfile.java
@@ -57,9 +57,10 @@ public class MemberSecondProfile extends BaseTimeEntity {
 //    @JoinColumn
 //    private Personality personality;
 
-    @ElementCollection
-    @Builder.Default
-    private Set<MBTI> mbti = new HashSet<>();
+    //@ElementCollection
+    //@Builder.Default
+    //private Set<MBTI> mbti = new HashSet<>();
+    private String mbti;
 
     private Boolean isHobbySame;
 

--- a/src/main/java/com/umc/meetpick/service/MatchingServiceImpl.java
+++ b/src/main/java/com/umc/meetpick/service/MatchingServiceImpl.java
@@ -69,7 +69,7 @@ public class MatchingServiceImpl implements MatchingService {
                 }
 
                 // MBTI 조건 체크
-                if(memberSecondProfile.getMbti() == null || memberSecondProfile.getMbti().contains(member.getMemberProfile().getMBTI())){
+                if(memberSecondProfile.getMbti() == null || memberSecondProfile.getMbti().contains(member.getMemberProfile().getMBTI().name())){
                     conditionMatching++;
                 }
 

--- a/src/main/java/com/umc/meetpick/service/request/RequestServiceImpl.java
+++ b/src/main/java/com/umc/meetpick/service/request/RequestServiceImpl.java
@@ -218,7 +218,7 @@ public class RequestServiceImpl implements RequestService {
 
         // 성격 판단 - 입력받은 mbti 가져와서 판단
         String joinMemberMBTI = joinMemberProfile.getMBTI().name();
-        String requestMBTI = request.getMbti().stream().map(Enum::name).collect(Collectors.joining());
+        String requestMBTI = request.getMbti();
         for (int i = 0; i < 4; i++){
             if(!(requestMBTI.charAt(i) == joinMemberMBTI.charAt(i)) && !(requestMBTI.charAt(i) == 'X')){
                 throw new IllegalArgumentException("성격 조건 안 맞음");


### PR DESCRIPTION
## #️⃣ 연관 이슈
83

## 📝 요약
- requestDTO에서 새로운 매칭 생성에 사용되는 mbti는 enum이 아니라 스트링으로 변경 - 프론트에서 "EXTJ"이런식으로 줘서
- requestServiceImpl에 관련 내용 수정
- memberSecondProfile 엔티티의 mbti 자료형 string으로 변경
- MatchingServiceImpl.java의 mbti 자료형 변경사항 반영

## 🙏 리뷰 요청사항
To 준형
MatchingServiceImpl.java에 mbti 조건 판별시 memberSecondProfile의 mbti가 string으로 바뀌면서 비교 로직을 enum에 .name()을 붙여서 문자열 비교로 처리했는데 혹시 이 부분이 문제 없는지 체크 부탁드림다!!


## ✅ PR 유형
<!-- 작업한 내용에 체크해주세요 -->
다음과 같은 **변경 사항**이 있습니다.
- [ ] 새로운 기능 추가
- [ ] 기존 로직 수정
- [X] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (주석 및 오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 문서 수정

