### PR TITLE
FIX: 헬스 텍스트 앞에 이모티콘 제거

### DIFF
--- a/src/main/java/com/umc/meetpick/enums/ExerciseType.java
+++ b/src/main/java/com/umc/meetpick/enums/ExerciseType.java
@@ -6,7 +6,7 @@ public enum ExerciseType {
     BOWLING("볼링"),
     CLIMBING("클라이밍"),
     TABLE_TENNIS("탁구"),
-    FITNESS("🏋헬스"),
+    FITNESS("헬스"),
     RUNNING("러닝/조깅"),
     SOCCER("축구/풋살"),
     BASKETBALL("농구"),


### PR DESCRIPTION
## #️⃣ 연관 이슈
144

## 📝 요약

- 헬스 앞에 이모티콘 제거

## ✅ PR 유형
<!-- 작업한 내용에 체크해주세요 -->
다음과 같은 **변경 사항**이 있습니다.
- [ ] 새로운 기능 추가
- [ ] 기존 로직 수정
- [X] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (주석 및 오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 문서 수정

